### PR TITLE
[WIP] Use rust abi to convert type

### DIFF
--- a/gcc/rust/Make-lang.in
+++ b/gcc/rust/Make-lang.in
@@ -32,8 +32,8 @@ rust1_OBJS = \
 RUST_SRCS = \
 	$(RUST_SRC_DIR)/src/lib.rs \
 	$(RUST_SRC_DIR)/src/gcc_api.rs \
-	$(RUST_SRC_DIR)/src/gcc_api_sys.rs \
-	$(RUST_SRC_DIR)/src/mir2gimple.rs
+	$(RUST_SRC_DIR)/src/mir2gimple.rs \
+	$(RUST_SRC_DIR)/src/convert_type.rs
 
 RUST_SYSROOT = $(shell cd "$(RUST_SRC_DIR)" && rustc --print sysroot)
 

--- a/gcc/rust/gcc-rust/src/convert_type.rs
+++ b/gcc/rust/gcc-rust/src/convert_type.rs
@@ -1,0 +1,316 @@
+use crate::gcc_api::*;
+use rustc::{
+    mir::{interpret::ConstValue, Body, Local},
+    ty::{
+        self, layout, subst::SubstsRef, AdtDef, AdtKind, ConstKind, ParamEnv, PolyFnSig, Ty,
+        TyCtxt, TyKind, VariantDef,
+    },
+};
+use rustc_hir::def_id::DefId;
+
+use std::collections::HashMap;
+
+pub struct ConvertedFnSig {
+    pub return_type: Tree,
+    pub arg_types: Vec<Tree>,
+}
+
+impl ConvertedFnSig {
+    pub fn into_function_type(self) -> Tree {
+        Tree::new_function_type(self.return_type, &self.arg_types)
+    }
+}
+
+/// Cache the types so if we convert the same anonymous type twice, we get the exact same
+/// Tree object. Otherwise, we get errors about anonymous structs not being the same, even
+/// though they have the same fields.
+pub struct TypeCache<'tcx> {
+    tcx: TyCtxt<'tcx>,
+    hashmap: HashMap<Ty<'tcx>, Tree>,
+}
+
+impl<'tcx> TypeCache<'tcx> {
+    pub fn new(tcx: TyCtxt<'tcx>) -> Self {
+        Self {
+            tcx,
+            hashmap: HashMap::new(),
+        }
+    }
+
+    fn make_zst() -> Tree {
+        // Use a zero-length array of whatever.
+        Tree::new_array_type(IntegerTypeKind::Int.into(), 0)
+    }
+
+    fn convert_variant_fields(
+        &mut self,
+        variant: &VariantDef,
+        substs: SubstsRef<'tcx>,
+    ) -> DeclList {
+        // TODO: field names
+        DeclList::new(
+            TreeCode::FieldDecl,
+            &variant
+                .fields
+                .iter()
+                .map(|field| {
+                    // TODO: should be using the struct's layout here
+                    let ty = field.ty(self.tcx, substs);
+                    self.convert_type(ty)
+                })
+                .collect::<Vec<_>>(),
+        )
+    }
+
+    fn convert_closure_upvars_struct(
+        &mut self,
+        closure_ty: Ty<'tcx>,
+        def_id: DefId,
+        substs: SubstsRef<'tcx>,
+    ) -> Tree {
+        let mut record_ty = Tree::new_record_type(TreeCode::RecordType);
+        self.hashmap.insert(closure_ty, record_ty);
+
+        let upvar_tys = substs
+            .as_closure()
+            .upvar_tys(def_id, self.tcx)
+            .map(|ty| self.convert_type(ty))
+            .collect::<Vec<_>>();
+
+        record_ty.finish_record_type(DeclList::new(TreeCode::FieldDecl, &upvar_tys));
+        record_ty
+    }
+
+    fn convert_slice(element_type: Tree) -> Tree {
+        // Represent a slice reference as a record containing (*T, size)
+        let t_ptr_ty = Tree::new_pointer_type(element_type);
+        // usize ?
+        let size_ty = Tree::new_unsigned_int_type(64);
+
+        let mut record_ty = Tree::new_record_type(TreeCode::RecordType);
+        record_ty.finish_record_type(DeclList::new(TreeCode::FieldDecl, &[t_ptr_ty, size_ty]));
+        record_ty
+    }
+
+    fn convert_trait_object(&mut self) -> Tree {
+        // Represent a trait object as a record containing (*object, *vtable)
+        // where vtable is *void
+        let mut record_ty = Tree::new_record_type(TreeCode::RecordType);
+        let void_ptr_ty = Tree::new_pointer_type(TreeIndex::VoidType.into());
+        let void_ptr_ptr_ty = Tree::new_pointer_type(void_ptr_ty);
+        record_ty.finish_record_type(DeclList::new(
+            TreeCode::FieldDecl,
+            &[void_ptr_ty, void_ptr_ptr_ty],
+        ));
+        record_ty
+    }
+
+    fn convert_integer(&mut self, int: &layout::Integer, is_signed: bool) -> Tree {
+        use layout::Integer::*;
+        if is_signed {
+            match int {
+                I8 => Tree::new_signed_int_type(8),
+                I16 => Tree::new_signed_int_type(16),
+                I32 => Tree::new_signed_int_type(32),
+                I64 => Tree::new_signed_int_type(64),
+                I128 => Tree::new_signed_int_type(128),
+            }
+        } else {
+            match int {
+                I8 => Tree::new_unsigned_int_type(8),
+                I16 => TreeIndex::Uint16Type.into(),
+                I32 => TreeIndex::Uint32Type.into(),
+                I64 => TreeIndex::Uint64Type.into(),
+                I128 => Tree::new_unsigned_int_type(128),
+            }
+        }
+    }
+
+    // TODO: Add offset in parameter
+    fn convert_scalar(&mut self, scalar: &layout::Scalar) -> Tree {
+        match scalar.value {
+            layout::Int(i, is_signed) => self.convert_integer(&i, is_signed),
+            layout::Pointer => {
+                // todo: better pointer type
+                Tree::new_pointer_type(Tree::new_unsigned_int_type(8))
+            }
+            _ => panic!("convert_scalar: {:?}", scalar),
+        }
+    }
+
+    fn convert_adt(&mut self, ty: Ty<'tcx>, adt_def: &AdtDef, substs: SubstsRef<'tcx>) -> Tree {
+        let layout = self.tcx.layout_of(ParamEnv::reveal_all().and(ty)).unwrap();
+
+        match &layout.abi {
+            layout::Abi::Scalar(s) => {
+                return self.convert_scalar(&s);
+            }
+            _ => {}
+        }
+
+        // Cache type before creating fields to avoid infinite recursion for
+        // self-referential types.
+        let code = match adt_def.adt_kind() {
+            AdtKind::Struct | AdtKind::Enum => TreeCode::RecordType,
+            AdtKind::Union => TreeCode::UnionType,
+        };
+
+        let mut tt = Tree::new_record_type(code);
+        self.hashmap.insert(ty, tt);
+
+        // Now add the fields...
+        match adt_def.adt_kind() {
+            AdtKind::Struct | AdtKind::Union => {
+                let variant = adt_def.non_enum_variant();
+                tt.finish_record_type(self.convert_variant_fields(variant, substs));
+            }
+
+            AdtKind::Enum => {
+                // Pretend it looks like
+                // struct {
+                //     long discriminant;
+                //     union {
+                //         variant1;
+                //         variant2;
+                //         ...
+                //     }
+                // }
+                //
+                // (It seems rustc expects the discriminant to be an isize, which is
+                // currently converted into a long.)
+
+                let discr_ty = Tree::new_signed_int_type(64);
+
+                let variants = adt_def
+                    .variants
+                    .iter()
+                    .map(|variant| {
+                        // afaik variants cannot currently be treated as a separate type,
+                        // so they can't be self-referential and we don't need to cache
+                        // them.
+                        let mut variant_ty = Tree::new_record_type(TreeCode::RecordType);
+                        variant_ty.finish_record_type(self.convert_variant_fields(variant, substs));
+                        variant_ty
+                    })
+                    .collect::<Vec<_>>();
+                let mut variant_union_ty = Tree::new_record_type(TreeCode::UnionType);
+                variant_union_ty.finish_record_type(DeclList::new(TreeCode::FieldDecl, &variants));
+
+                tt.finish_record_type(DeclList::new(
+                    TreeCode::FieldDecl,
+                    &[discr_ty, variant_union_ty],
+                ));
+            }
+        }
+
+        tt
+    }
+
+    fn do_convert_type(&mut self, ty: Ty<'tcx>) -> Tree {
+        if ty.kind == TyKind::Bool {
+            return TreeIndex::BooleanType.into();
+        }
+
+        let layout = self.tcx.layout_of(ParamEnv::reveal_all().and(ty)).unwrap();
+
+		if layout.is_zst() {
+			return Self::make_zst();
+		}
+
+        // todo: use a different cache for scalar value
+        // see https://github.com/rust-lang/rust/blob/bc1571cc3cfef07251f7df52b95525aa16797ca2/src/librustc_codegen_llvm/type_of.rs#L237
+        match layout.abi {
+            layout::Abi::Scalar(ref scalar) => {
+                return match ty.kind {
+                    ty::RawPtr(ty::TypeAndMut { ty, mutbl: _ }) | ty::Ref(_, ty, _) => {
+                        Tree::new_pointer_type(self.convert_type(ty))
+                    }
+
+                    ty::Adt(def, _) if def.is_box() => todo!("Box"),
+                    ty::FnPtr(sig) => {
+                        Tree::new_pointer_type(self.convert_fn_sig(sig).into_function_type())
+                    }
+                    _ => self.convert_scalar(scalar),
+                };
+            }
+            layout::Abi::ScalarPair(ref s1, ref s2) => {
+                let fields = DeclList::new(
+                    TreeCode::FieldDecl,
+                    &[self.convert_scalar(s1), self.convert_scalar(s2)],
+                );
+
+                let mut ty = Tree::new_record_type(TreeCode::RecordType);
+                ty.finish_record_type(fields);
+                return ty;
+            }
+            layout::Abi::Vector { ref element, count } => {
+                return Tree::new_array_type(self.convert_scalar(element), count);
+            }
+            _ => {}
+        }
+
+        match &layout.fields {
+            layout::FieldPlacement::Union(field_count) => todo!(),
+            layout::FieldPlacement::Array { stride, count } => todo!(),
+            layout::FieldPlacement::Arbitrary {
+                offsets,
+                memory_index,
+            } => {
+				println!("offsets: {:?}, index: {:?}", offsets, memory_index);
+				todo!()
+			},
+        }
+    }
+
+    pub fn convert_type(&mut self, ty: Ty<'tcx>) -> Tree {
+        if let Some(tree) = self.hashmap.get(ty) {
+            return *tree;
+        }
+
+        // TODO: return a placeholder when called recursively!
+        // do_convert_type can recursively call convert_type
+        let mut tree = self.do_convert_type(ty);
+        tree.set_type_name(Tree::new_identifier(format!("{}", ty)));
+        *self.hashmap.entry(ty).or_insert(tree)
+    }
+
+    pub fn convert_fn_return_type(&mut self, ty: Ty<'tcx>) -> Tree {
+        if ty.is_unit() {
+            TreeIndex::VoidType.into()
+        } else {
+            self.convert_type(ty)
+        }
+    }
+
+    pub fn convert_fn_sig(&mut self, fn_sig: PolyFnSig<'tcx>) -> ConvertedFnSig {
+        // TODO: fn_sig.c_variadic, fn_sig.abi
+        let inputs_and_output = fn_sig.inputs_and_output();
+        let inputs_and_output = self
+            .tcx
+            .normalize_erasing_late_bound_regions(ParamEnv::reveal_all(), &inputs_and_output);
+        let (return_type, arg_types) = inputs_and_output.split_last().expect("missing return type");
+
+        let return_type = self.convert_fn_return_type(return_type);
+        let arg_types = arg_types
+            .into_iter()
+            .map(|arg| self.convert_type(arg))
+            .collect();
+
+        ConvertedFnSig {
+            return_type,
+            arg_types,
+        }
+    }
+
+    pub fn convert_local_decl_types<I>(&mut self, body: &Body<'tcx>, iter: I) -> Vec<Tree>
+    where
+        I: Iterator<Item = Local>,
+    {
+        iter.map(|local| self.convert_type(body.local_decls[local].ty))
+            .collect()
+    }
+
+    pub fn convert_fn_arg_types(&mut self, body: &Body<'tcx>) -> Vec<Tree> {
+        self.convert_local_decl_types(body, body.args_iter())
+    }
+}

--- a/gcc/rust/gcc-rust/src/lib.rs
+++ b/gcc/rust/gcc-rust/src/lib.rs
@@ -18,6 +18,7 @@ extern crate syntax;
 mod gcc_api;
 mod gcc_api_sys;
 mod mir2gimple;
+mod convert_type;
 
 use gcc_api::get_crate_type;
 use rustc_driver::Compilation;

--- a/gcc/rust/gcc-rust/src/mir2gimple.rs
+++ b/gcc/rust/gcc-rust/src/mir2gimple.rs
@@ -13,8 +13,8 @@ use rustc::{
         adjustment::PointerCast,
         layout::{Size, TyLayout},
         subst::{Subst, SubstsRef},
-        AdtDef, AdtKind, Const, ConstKind, Instance, InstanceDef, ParamEnv,
-        PolyExistentialTraitRef, PolyFnSig, Ty, TyCtxt, TyKind, TyS, TypeAndMut, VariantDef,
+        AdtKind, Const, ConstKind, Instance, InstanceDef, ParamEnv, PolyExistentialTraitRef,
+        PolyFnSig, Ty, TyCtxt, TyKind, TyS,
     },
 };
 use rustc_hir::def_id::DefId;
@@ -23,7 +23,8 @@ use rustc_mir::monomorphize::collector::{collect_crate_mono_items, MonoItemColle
 use rustc_span::symbol::Symbol;
 use rustc_target::spec::abi::Abi;
 use std::{collections::HashMap, convert::TryInto, ffi::CString};
-use syntax::ast::{IntTy, UintTy};
+
+use crate::convert_type::TypeCache;
 
 // Copied from https://github.com/bjorn3/rustc_codegen_cranelift/blob/7ff01a4d59779609992aad947264abcc64617917/src/abi/mod.rs#L15
 // Copied from https://github.com/rust-lang/rust/blob/c2f4c57296f0d929618baed0b0d6eb594abf01eb/src/librustc/ty/layout.rs#L2349
@@ -91,293 +92,6 @@ fn fn_sig_for_fn_abi<'tcx>(tcx: TyCtxt<'tcx>, instance: Instance<'tcx>) -> PolyF
 
 const USIZE_KIND: SizeTypeKind = SizeTypeKind::UnsignedBytes;
 const ISIZE_KIND: SizeTypeKind = SizeTypeKind::SignedBytes;
-
-struct ConvertedFnSig {
-    pub return_type: Tree,
-    pub arg_types: Vec<Tree>,
-}
-
-impl ConvertedFnSig {
-    fn into_function_type(self) -> Tree {
-        Tree::new_function_type(self.return_type, &self.arg_types)
-    }
-}
-
-/// Cache the types so if we convert the same anonymous type twice, we get the exact same
-/// Tree object. Otherwise, we get errors about anonymous structs not being the same, even
-/// though they have the same fields.
-struct TypeCache<'tcx> {
-    tcx: TyCtxt<'tcx>,
-    hashmap: HashMap<Ty<'tcx>, Tree>,
-}
-
-impl<'tcx> TypeCache<'tcx> {
-    fn new(tcx: TyCtxt<'tcx>) -> Self {
-        Self {
-            tcx,
-            hashmap: HashMap::new(),
-        }
-    }
-
-    fn make_zst() -> Tree {
-        // Use a zero-length array of whatever.
-        Tree::new_array_type(IntegerTypeKind::Int.into(), 0)
-    }
-
-    fn convert_variant_fields(
-        &mut self,
-        variant: &VariantDef,
-        substs: SubstsRef<'tcx>,
-    ) -> DeclList {
-        // TODO: field names
-        DeclList::new(
-            TreeCode::FieldDecl,
-            &variant
-                .fields
-                .iter()
-                .map(|field| {
-                    // TODO: should be using the struct's layout here
-                    let ty = field.ty(self.tcx, substs);
-                    self.convert_type(ty)
-                })
-                .collect::<Vec<_>>(),
-        )
-    }
-
-    fn convert_closure_upvars_struct(
-        &mut self,
-        closure_ty: Ty<'tcx>,
-        def_id: DefId,
-        substs: SubstsRef<'tcx>,
-    ) -> Tree {
-        let mut record_ty = Tree::new_record_type(TreeCode::RecordType);
-        self.hashmap.insert(closure_ty, record_ty);
-
-        let upvar_tys = substs
-            .as_closure()
-            .upvar_tys(def_id, self.tcx)
-            .map(|ty| self.convert_type(ty))
-            .collect::<Vec<_>>();
-
-        record_ty.finish_record_type(DeclList::new(TreeCode::FieldDecl, &upvar_tys));
-        record_ty
-    }
-
-    fn convert_slice(element_type: Tree) -> Tree {
-        // Represent a slice reference as a record containing (*T, size)
-        let t_ptr_ty = Tree::new_pointer_type(element_type);
-        let size_ty = USIZE_KIND.into();
-
-        let mut record_ty = Tree::new_record_type(TreeCode::RecordType);
-        record_ty.finish_record_type(DeclList::new(TreeCode::FieldDecl, &[t_ptr_ty, size_ty]));
-        record_ty
-    }
-
-    fn convert_trait_object(&mut self) -> Tree {
-        // Represent a trait object as a record containing (*object, *vtable)
-        // where vtable is *void
-        let mut record_ty = Tree::new_record_type(TreeCode::RecordType);
-        let void_ptr_ty = Tree::new_pointer_type(TreeIndex::VoidType.into());
-        let void_ptr_ptr_ty = Tree::new_pointer_type(void_ptr_ty);
-        record_ty.finish_record_type(DeclList::new(
-            TreeCode::FieldDecl,
-            &[void_ptr_ty, void_ptr_ptr_ty],
-        ));
-        record_ty
-    }
-
-    fn convert_adt(&mut self, ty: Ty<'tcx>, adt_def: &AdtDef, substs: SubstsRef<'tcx>) -> Tree {
-        // Cache type before creating fields to avoid infinite recursion for
-        // self-referential types.
-        let code = match adt_def.adt_kind() {
-            AdtKind::Struct | AdtKind::Enum => TreeCode::RecordType,
-            AdtKind::Union => TreeCode::UnionType,
-        };
-
-        let mut tt = Tree::new_record_type(code);
-        self.hashmap.insert(ty, tt);
-
-        // Now add the fields...
-        match adt_def.adt_kind() {
-            AdtKind::Struct | AdtKind::Union => {
-                let variant = adt_def.non_enum_variant();
-                tt.finish_record_type(self.convert_variant_fields(variant, substs));
-            }
-
-            AdtKind::Enum => {
-                // Pretend it looks like
-                // struct {
-                //     long discriminant;
-                //     union {
-                //         variant1;
-                //         variant2;
-                //         ...
-                //     }
-                // }
-                //
-                // (It seems rustc expects the discriminant to be an isize, which is
-                // currently converted into a long.)
-
-                let discr_ty = ISIZE_KIND.into();
-
-                let variants = adt_def
-                    .variants
-                    .iter()
-                    .map(|variant| {
-                        // afaik variants cannot currently be treated as a separate type,
-                        // so they can't be self-referential and we don't need to cache
-                        // them.
-                        let mut variant_ty = Tree::new_record_type(TreeCode::RecordType);
-                        variant_ty.finish_record_type(self.convert_variant_fields(variant, substs));
-                        variant_ty
-                    })
-                    .collect::<Vec<_>>();
-                let mut variant_union_ty = Tree::new_record_type(TreeCode::UnionType);
-                variant_union_ty.finish_record_type(DeclList::new(TreeCode::FieldDecl, &variants));
-
-                tt.finish_record_type(DeclList::new(
-                    TreeCode::FieldDecl,
-                    &[discr_ty, variant_union_ty],
-                ));
-            }
-        }
-
-        tt
-    }
-
-    fn do_convert_type(&mut self, ty: Ty<'tcx>) -> Tree {
-        use TyKind::*;
-
-        match ty.kind {
-            Bool => TreeIndex::BooleanType.into(),
-            Int(IntTy::Isize) => ISIZE_KIND.into(),
-            Int(IntTy::I8) => Tree::new_signed_int_type(8),
-            Int(IntTy::I16) => Tree::new_signed_int_type(16),
-            Int(IntTy::I32) => Tree::new_signed_int_type(32),
-            Int(IntTy::I64) => Tree::new_signed_int_type(64),
-            Uint(UintTy::Usize) => USIZE_KIND.into(),
-            Uint(UintTy::U8) => Tree::new_unsigned_int_type(8),
-            Uint(UintTy::U16) => TreeIndex::Uint16Type.into(),
-            Uint(UintTy::U32) => TreeIndex::Uint32Type.into(),
-            Uint(UintTy::U64) => TreeIndex::Uint64Type.into(),
-            Char => TreeIndex::Uint32Type.into(),
-
-            Tuple(substs) => {
-                if substs.is_empty() {
-                    // This is the unit type.
-                    // For function return types, convert_fn_return_type() converts it to void,
-                    // but in other contexts, we treat it like other ZSTs, so that it can be
-                    // instantiated.
-                    Self::make_zst()
-                } else {
-                    let fields = DeclList::new(
-                        TreeCode::FieldDecl,
-                        &substs
-                            .types()
-                            .map(|field_ty| self.convert_type(field_ty))
-                            .collect::<Vec<_>>(),
-                    );
-
-                    let mut ty = Tree::new_record_type(TreeCode::RecordType);
-                    ty.finish_record_type(fields);
-                    ty
-                }
-            }
-
-            Adt(adt_def, substs) => self.convert_adt(ty, adt_def, substs),
-
-            // TODO: mutability
-            RawPtr(TypeAndMut { ty, mutbl: _ }) | Ref(_, ty, _) => {
-                if let Slice(element_type) = ty.kind {
-                    Self::convert_slice(self.convert_type(element_type))
-                } else if let Str = ty.kind {
-                    Self::convert_slice(IntegerTypeKind::UnsignedChar.into())
-                } else if let Dynamic(..) = ty.kind {
-                    self.convert_trait_object()
-                } else {
-                    Tree::new_pointer_type(self.convert_type(ty))
-                }
-            }
-
-            FnDef(..) => Self::make_zst(),
-
-            FnPtr(sig) => Tree::new_pointer_type(self.convert_fn_sig(sig).into_function_type()),
-
-            Projection(_proj_ty) => unreachable!(concat!(
-                "Projection types should have been resolved previously by",
-                " subst_and_normalize_erasing_regions"
-            )),
-
-            Array(element_type, num_elements) => {
-                if let ConstKind::Value(ConstValue::Scalar(num_elements)) = num_elements.val {
-                    let num_elements = num_elements.to_u64().expect("expected bits, got a ptr?");
-                    Tree::new_array_type(self.convert_type(element_type), num_elements)
-                } else {
-                    unreachable!("array with non-const number of elements");
-                }
-            }
-
-            // It never gets instantiated, so I think it shouldn't matter which type we use here.
-            Never => TreeIndex::VoidType.into(),
-
-            Closure(def_id, substs) => self.convert_closure_upvars_struct(ty, def_id, substs),
-
-            _ => unimplemented!("type: {:?} ({:?})", ty, ty.kind),
-        }
-    }
-
-    fn convert_type(&mut self, ty: Ty<'tcx>) -> Tree {
-        if let Some(tree) = self.hashmap.get(ty) {
-            return *tree;
-        }
-
-        // TODO: return a placeholder when called recursively!
-        // do_convert_type can recursively call convert_type
-        let mut tree = self.do_convert_type(ty);
-        tree.set_type_name(Tree::new_identifier(format!("{}", ty)));
-        *self.hashmap.entry(ty).or_insert(tree)
-    }
-
-    fn convert_fn_return_type(&mut self, ty: Ty<'tcx>) -> Tree {
-        if ty.is_unit() {
-            TreeIndex::VoidType.into()
-        } else {
-            self.convert_type(ty)
-        }
-    }
-
-    fn convert_fn_sig(&mut self, fn_sig: PolyFnSig<'tcx>) -> ConvertedFnSig {
-        // TODO: fn_sig.c_variadic, fn_sig.abi
-        let inputs_and_output = fn_sig.inputs_and_output();
-        let inputs_and_output = self
-            .tcx
-            .normalize_erasing_late_bound_regions(ParamEnv::reveal_all(), &inputs_and_output);
-        let (return_type, arg_types) = inputs_and_output.split_last().expect("missing return type");
-
-        let return_type = self.convert_fn_return_type(return_type);
-        let arg_types = arg_types
-            .into_iter()
-            .map(|arg| self.convert_type(arg))
-            .collect();
-
-        ConvertedFnSig {
-            return_type,
-            arg_types,
-        }
-    }
-
-    fn convert_local_decl_types<I>(&mut self, body: &Body<'tcx>, iter: I) -> Vec<Tree>
-    where
-        I: Iterator<Item = Local>,
-    {
-        iter.map(|local| self.convert_type(body.local_decls[local].ty))
-            .collect()
-    }
-
-    fn convert_fn_arg_types(&mut self, body: &Body<'tcx>) -> Vec<Tree> {
-        self.convert_local_decl_types(body, body.args_iter())
-    }
-}
 
 struct ConversionCtx<'tcx> {
     tcx: TyCtxt<'tcx>,
@@ -769,23 +483,26 @@ impl<'a, 'tcx, 'body> FunctionConversion<'a, 'tcx, 'body> {
                     }
 
                     Tuple(substs) if substs.is_empty() => TreeIndex::Void.into(),
-
+                    // Can an adt be initialised with a scalar const
+                    // without being represented himself as scalar ?
                     Adt(adt_def, _substs) if adt_def.adt_kind() == AdtKind::Struct => {
                         let type_ = self.convert_type(const_.ty);
 
                         let layout = self.conv_ctx.layout_of(const_.ty);
-                        let constructor = if layout.is_zst() {
-                            Tree::new_record_constructor(
+                        if layout.is_zst() {
+                            let constructor = Tree::new_record_constructor(
                                 type_,
                                 // no fields, it's a ZST
                                 &[],
                                 &[],
-                            )
+                            );
+                            Tree::new_compound_literal_expr(type_, constructor, self.fn_decl.0)
                         } else {
-                            todo!("non-ZST Adt literal")
-                        };
-
-                        Tree::new_compound_literal_expr(type_, constructor, self.fn_decl.0)
+                            Tree::new_int_constant(
+                                type_,
+                                scalar.assert_bits(size).try_into().unwrap(),
+                            )
+                        }
                     }
 
                     FnDef(..) => self.make_zst_literal(const_.ty),
@@ -816,8 +533,13 @@ impl<'a, 'tcx, 'body> FunctionConversion<'a, 'tcx, 'body> {
             use ProjectionElem::*;
 
             match elem {
-                Field(field_index, _field_ty) => {
-                    component = Tree::new_record_field_ref(component, field_index.as_usize());
+                Field(field_index, field_ty) => {
+                    let layout = self.conv_ctx.layout_of(field_ty);
+                    if layout.details.abi.is_scalar() {
+                        // don't do anything
+                    } else {
+                        component = Tree::new_record_field_ref(component, field_index.as_usize());
+                    }
                 }
 
                 Downcast(_, variant_index) => {


### PR DESCRIPTION
Use rust abi to convert type, like suggested in https://github.com/sapir/gcc-rust/issues/15.
Follow the same pattern as the llvm codegen of rust, this should lead to binary compatibility between crate compiled by the 2 backend for free.

Will fix https://github.com/sapir/gcc-rust/issues/9.

The code is in a very early stage, it will affect almost all the codegen.